### PR TITLE
ROSA: Prefer dnf over urpmi

### DIFF
--- a/implementation/rosa/setup.sh
+++ b/implementation/rosa/setup.sh
@@ -29,8 +29,15 @@ function _install_packages ()
         fi
 
 	echolog "Rosa. install common packages"
-	INSTALLCMD="urpmi --force"
-	[ -f /usr/bin/urpmi ] || INSTALLCMD="dnf install -y"
+	# rosa2019.1+ uses dnf as the main package manager,
+	# but urpmi command may be available from dnf-URPM converter;
+	# dnf is never available on platforms where urpmi is the only package manager.
+	if command -v dnf >/dev/null 2>&1
+	then
+		INSTALLCMD="dnf install -y"
+	else
+		INSTALLCMD="urpmi --force"
+	fi
 	sudo $INSTALLCMD $pkgs
 	if [[ $? -ne 0 ]]
 	then


### PR DESCRIPTION
Commit 97843a9304 ("fixes for rosa 2019.1 platform") added support for using dnf in rosa2019.1+ where urpmi was changed to dnf.
But there is a converter of urpmi and urpme commands to dnf - dnf-URPM https://github.com/rpm-software-management/dnf-URPM
It will be pre-installed in most ROSA 2019.1-based distros.
Code from commit 97843a9304 will use a converter in this case, what does not make sense.
Use dnf directly if it is available.
There are no cases when dnf is available in urpmi-based ditros, it is just not packaged there.

Fixes: https://github.com/AktivCo/2fa-tuner-lib/pull/1

CC @betcher