### PR TITLE
rosa: update list of packages

### DIFF
--- a/implementation/rosa/setup.sh
+++ b/implementation/rosa/setup.sh
@@ -18,7 +18,7 @@ function check_pkgs ()
 
 function _install_packages ()
 {
-        local pkgs="ccid opensc p11-kit rpmdevtools dialog lib64p11-devel engine_pkcs11 pam_pkcs11 pam_pkcs11-tools tkinter3 pcsc_tools gettext"
+        local pkgs="ccid opensc p11-kit dialog engine_pkcs11 pam_pkcs11 pam_pkcs11-tools tkinter3 pcsc-tools gettext"
         check_update="$1"
 
         if [[ "$check_updates" ]]


### PR DESCRIPTION
lib64p11-devel package with only *.h and a symlink *.so is not needed, I guess
$ dnf rq -l lib54p11-devel
/usr/include/libp11.h
/usr/include/p11_err.h
/usr/lib64/libp11.so
/usr/lib64/pkgconfig/libp11.pc
No binaries from rpmdevtools are used.
Fixes: https://github.com/AktivCo/rutoken-linux-gui-manager/issues/3

Fix typo: pcsc_tols -> pcsc-tools
Fixes: https://github.com/AktivCo/2fa-tuner-lib/issues/3